### PR TITLE
Fix frmelementdesigner paints component out of view

### DIFF
--- a/SimpleAnnPlayground/Debugging/FrmElementDesigner.Designer.cs
+++ b/SimpleAnnPlayground/Debugging/FrmElementDesigner.Designer.cs
@@ -104,8 +104,8 @@
             // 
             // PicDraw
             // 
+            this.PicDraw.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.PicDraw.BackColor = System.Drawing.Color.White;
-            this.PicDraw.Dock = System.Windows.Forms.DockStyle.Fill;
             this.PicDraw.Location = new System.Drawing.Point(0, 0);
             this.PicDraw.Name = "PicDraw";
             this.PicDraw.Size = new System.Drawing.Size(449, 423);
@@ -306,9 +306,9 @@
             this.LstConnectors.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LstConnectors.FormattingEnabled = true;
             this.LstConnectors.ItemHeight = 20;
-            this.LstConnectors.Location = new System.Drawing.Point(32, 24);
+            this.LstConnectors.Location = new System.Drawing.Point(24, 24);
             this.LstConnectors.Name = "LstConnectors";
-            this.LstConnectors.Size = new System.Drawing.Size(154, 87);
+            this.LstConnectors.Size = new System.Drawing.Size(162, 87);
             this.LstConnectors.TabIndex = 1;
             this.LstConnectors.SelectedIndexChanged += new System.EventHandler(this.LstConnectors_SelectedIndexChanged);
             // 
@@ -321,7 +321,7 @@
             this.BtnDeleteConnector});
             this.toolStrip1.Location = new System.Drawing.Point(0, 24);
             this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(32, 87);
+            this.toolStrip1.Size = new System.Drawing.Size(24, 87);
             this.toolStrip1.TabIndex = 2;
             this.toolStrip1.Text = "toolStrip1";
             // 
@@ -331,7 +331,7 @@
             this.BtnAddConnector.Image = global::SimpleAnnPlayground.Properties.Resources.d_add;
             this.BtnAddConnector.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.BtnAddConnector.Name = "BtnAddConnector";
-            this.BtnAddConnector.Size = new System.Drawing.Size(29, 20);
+            this.BtnAddConnector.Size = new System.Drawing.Size(21, 20);
             this.BtnAddConnector.Text = "Add connector";
             this.BtnAddConnector.Click += new System.EventHandler(this.BtnAddConnector_Click);
             // 
@@ -342,7 +342,7 @@
             this.BtnDeleteConnector.Image = global::SimpleAnnPlayground.Properties.Resources.d_remove;
             this.BtnDeleteConnector.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.BtnDeleteConnector.Name = "BtnDeleteConnector";
-            this.BtnDeleteConnector.Size = new System.Drawing.Size(29, 20);
+            this.BtnDeleteConnector.Size = new System.Drawing.Size(21, 20);
             this.BtnDeleteConnector.Text = "Remove connector";
             this.BtnDeleteConnector.Click += new System.EventHandler(this.BtnDeleteConnector_Click);
             // 

--- a/SimpleAnnPlayground/Debugging/FrmElementDesigner.cs
+++ b/SimpleAnnPlayground/Debugging/FrmElementDesigner.cs
@@ -40,7 +40,7 @@ namespace SimpleAnnPlayground.Debugging
         {
             InitializeComponent();
 
-            _component = new Component();
+            _component = new Component(PicDraw.Width / 2, PicDraw.Height / 2);
 
             FileManager = new TextFileManager();
             FileManager.AddFileFormat("cmpt", "Draw component.");
@@ -53,6 +53,7 @@ namespace SimpleAnnPlayground.Debugging
             }
 
             _busy = false;
+            _drawCenter = true;
         }
 
         /// <summary>
@@ -171,6 +172,7 @@ namespace SimpleAnnPlayground.Debugging
             if (_drawCenter)
             {
                 const int CROSS_SIZE = 3;
+
                 var cross = new Cross(Color.Red, _component.Center, CROSS_SIZE);
                 cross.Paint(e.Graphics);
             }
@@ -222,6 +224,7 @@ namespace SimpleAnnPlayground.Debugging
 
             LstModes.SelectedIndex = 0;
             PgdProperties.SelectedObject = _component;
+
             _drawCenter = true;
 
             // Paint objects in the picture box

--- a/SimpleAnnPlayground/Graphical/Models/Component.cs
+++ b/SimpleAnnPlayground/Graphical/Models/Component.cs
@@ -26,6 +26,22 @@ namespace SimpleAnnPlayground.Graphical
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Component"/> class, it's an override of the previous Component() method.
+        /// </summary>
+        /// <param name="xSize">The center width of the parent.</param>
+        /// <param name="ySize">The center height of the parent.</param>
+        public Component(float xSize, float ySize)
+        {
+            Elements = new Collection<Element>();
+            Connectors = new Collection<Connector>();
+            Selector = new Selector(0f, 0f);
+            X = xSize;
+            Y = ySize;
+            DefaultX = X;
+            DefaultY = Y;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Component"/> class.
         /// </summary>
         /// <param name="text">The text string containing the Component information.</param>
@@ -99,6 +115,16 @@ namespace SimpleAnnPlayground.Graphical
             /// </summary>
             ComponentError = 128,
         }
+
+        /// <summary>
+        /// Gets or sets the X center of component <seealso cref="DefaultX"/> objects of this component.
+        /// </summary>
+        public float DefaultX { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Y center of component <seealso cref="DefaultY"/> objects of this component.
+        /// </summary>
+        public float DefaultY { get; set; }
 
         /// <summary>
         /// Gets the collection of <seealso cref="Connector"/> objects of this component.
@@ -179,6 +205,8 @@ namespace SimpleAnnPlayground.Graphical
         /// <param name="text">The string containing the serialized elements.</param>
         public void Deserialize(string text)
         {
+            X = DefaultX;
+            Y = DefaultY;
             if (text == null) return;
             var elements = new Collection<Element>();
             var connectors = new Collection<Connector>();
@@ -225,8 +253,10 @@ namespace SimpleAnnPlayground.Graphical
                     case nameof(Center):
                     {
                         var center = TextSerializer.Deserialize(item.Value).ToDictionary(pair => pair.Key, pair => float.Parse(pair.Value, CultureInfo.CurrentCulture));
-                        X = center[nameof(X)];
-                        Y = center[nameof(Y)];
+                        X += -center[nameof(X)];
+                        Y += -center[nameof(Y)];
+                        X = -X;
+                        Y = -Y;
                         break;
                     }
                 }


### PR DESCRIPTION
Now frmelementdesigner paints in the center.
Component's constructor added in order to get  X and Y positions (center of the window), new DefaultX and DefaultY variables added to keep window's center. 
In Deserialize method, in case "nameof(Center)", X and Y are incremental now.